### PR TITLE
Default port and timeout added + small refactor

### DIFF
--- a/internal/decode.sh
+++ b/internal/decode.sh
@@ -1,32 +1,40 @@
 #!/bin/bash
 
-if [ "$2" = "" ]; then
-	echo "usage: $0 <field> <entry>"
-	exit 1
-elif [ "$1" != "host" ] && [ "$1" != "port" ] && [ "$1" != "tag" ] && [ "$1" != "timeout" ]; then
-	echo "error: invalid field \"$1\""
-	exit 1
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <field> <entry>"
+  exit 1
+elif ! [[ "$1" =~ ^(host|port|tag|timeout)$ ]]; then
+  echo "error: invalid field \"$1\""
+  exit 1
 fi
 
 field=$1
 server=$2
 
+DEFAULT_TIMEOUT=5
+DEFAULT_PORT=22
+
 if [[ $server =~ ^[a-z0-9.-]+$ ]]; then
-	server="$server::"
+  server="$server::"
 elif [[ $server =~ ^[a-z0-9.-]+[:][0-9]+$ ]]; then
-	server="$server:"
+  server="$server:"
 fi
 
-if [ "$1" = "host" ]; then
-	echo $server |cut -d: -f1
-elif [ "$1" = "tag" ]; then
-	echo $server |cut -d: -f3
-elif [ "$1" = "timeout" ]; then
-	timeout=`echo $server |cut -d: -f4`
-	if [ "$timeout" = "" ]; then timeout=60; fi
-	echo $timeout
-else
-	port=`echo $server |cut -d: -f2`
-	if [ "$port" = "" ]; then port=22; fi
-	echo $port
-fi
+case "$field" in
+host)
+  echo "$server" | cut -d: -f1
+  ;;
+tag)
+  echo "$server" | cut -d: -f3
+  ;;
+timeout)
+  timeout=$(echo "$server" | cut -d: -f4)
+  if [ "$timeout" = "" ]; then timeout=$DEFAULT_TIMEOUT; fi
+  echo $timeout
+  ;;
+port)
+  port=$(echo "$server" | cut -d: -f2)
+  if [ "$port" = "" ]; then port=$DEFAULT_PORT; fi
+  echo $port
+  ;;
+esac


### PR DESCRIPTION
Problem:
When connecting to server blocked by firewall we're heading with 1 minute timeout. 

Changes:
1. Introduced DEFAULT_TIMEOUT and DEFAULT_PORT constants
2. Default timeout is 5 seconds, default port is 22
3. Replaced long if condition with switch
4. Replaced required parameters check with regular expression instead of multiple if statements
5. Checking count of params instead of empty value in the second one